### PR TITLE
Added the ability to use CDATA in element text

### DIFF
--- a/src/XMLFragment.coffee
+++ b/src/XMLFragment.coffee
@@ -47,7 +47,7 @@ class XMLFragment
       throw new Error "Text nodes cannot have child nodes"
     if not value?
       throw new Error "Missing element text"
-    if not String(value).match("^" + @val.EntityValue + "$") and not String(value).match("^" + @val.CDATA + "$")
+    if not String(value).match("^" + @val.EntityValue + "$") and not String(value).match(@val.CDATA)
       throw new Error "Invalid element text: " + value
 
     child = new XMLFragment @, '', {}, value
@@ -182,7 +182,7 @@ XMLFragment::val.ExternalID =
   '(?:' + 'SYSTEM' + XMLFragment::val.Space + XMLFragment::val.SystemLiteral + ')|'
   '(?:' + 'PUBLIC' + XMLFragment::val.Space + XMLFragment::val.PubIDLateral +
   XMLFragment::val.Space + XMLFragment::val.SystemLiteral
-XMLFragment::val.CDATA = '<![CDATA[.*?]]>'
+XMLFragment::val.CDATA = /^\<!\[CDATA\[.*?\]\]\>$/
 
 
 module.exports = XMLFragment

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var xml = '<root>' +
             '<xmlbuilder for="node-js" awesome="CoffeeScript">' +
               '<repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>' +
             '</xmlbuilder>' +
-	    '<cdata><![CDATA[<test>this is a test</test>]]></cdata>' +
+	    '<cdata><![CDATA[<test att="val">this is a test</test>]]></cdata>' +
 	    '<test>complete</test>' +
           '</root>';
 
@@ -20,7 +20,7 @@ builder.begin('root')
   .up()
 .up()
 .ele('cdata')
-  .txt('<![CDATA[<test>this is a test</test>]]>')
+  .txt('<![CDATA[<test att="val">this is a test</test>]]>')
   .up()
 .up()
 .ele('test')


### PR DESCRIPTION
Previously, xmlbuilder-js would not allow CDATA in element text.  I have added a new Regular Expression to test for "<![CDATA[.*?]]>"  and added that to the test for valid text.

I have also updated the test case to include a test for CDATA.

Great utility by the way,
Joe Williams
