### PR TITLE
Allow multiple builder instances

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,4 +1,4 @@
 XMLBuilder = require './XMLBuilder'
 
-module.exports = new XMLBuilder()
+module.exports = -> new XMLBuilder()
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,5 +1,5 @@
 assert = require('assert')
-builder = require '../src/index.coffee'
+builder = require('../src/index.coffee')()
 
 xml = '<root>' +
         '<xmlbuilder for="node-js">' +


### PR DESCRIPTION
Right now the index.coffee exports only a single XMLBuilder instance.
This is problematic when building multiple XML's within a single node
process as it's essentially a singleton where none should be used.

This patch fixes it, but breaks API slightly.
