### PR TITLE
Fix: npm WARN xmlbuilder@0.1.2 package.json: bugs['web'] should probably be bugs['url']

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     } 
   ],
   "bugs": {
-    "web": "http://github.com/oozcitak/xmlbuilder-js/issues"
+    "url": "http://github.com/oozcitak/xmlbuilder-js/issues"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
Fix: npm WARN xmlbuilder@0.1.2 package.json: bugs['web'] should probably be bugs['url']
