### PR TITLE
Fix a duplicated escaping problem on element()

### DIFF
--- a/src/XMLFragment.coffee
+++ b/src/XMLFragment.coffee
@@ -47,7 +47,7 @@ class XMLFragment
       text = '' + text or ''
       text = @escape text
       @assertLegalChar text
-      child.text text
+      child.raw text
 
     @children.push child
     return child

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -156,3 +156,9 @@ test7 = builder.begin('test7')
         .doc().toString()
 assert.strictEqual(xml7, test7)
 
+# test escape of "
+xml8 = '<test8><node>&quot;</node></test8>'
+test8 = builder.begin('test8')
+      .ele('node', '"')
+      .doc().toString()
+assert.strictEqual(xml8, test8)


### PR DESCRIPTION
The text argument of XMLFragment#element() is escaped twice.
The solution is provided by @kou.
