### PR TITLE
Fix a problem with text node creation from ''

### DIFF
--- a/src/XMLFragment.coffee
+++ b/src/XMLFragment.coffee
@@ -305,7 +305,7 @@ class XMLFragment
     # open tag
     if pretty
       r += space
-    if not @value
+    if not @value?
       r += '<' + @name
     else
       r += '' + @value
@@ -319,7 +319,7 @@ class XMLFragment
 
     if @children.length == 0
       # empty element
-      if not @value
+      if not @value?
         r += if @name == '?xml' then '?>' else if @name == '!DOCTYPE' then '>' else '/>'
       if pretty
         r += newline

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -156,3 +156,8 @@ test7 = builder.begin('test7')
         .doc().toString()
 assert.strictEqual(xml7, test7)
 
+# Test text node with empty string
+xml9 = '<test9></test9>'
+test9 = builder.begin('test9').text('')
+  .doc().toString()
+assert.strictEqual(xml9, test9)


### PR DESCRIPTION
Fixed a problem that

```
builder.begin('node').text('').doc().toString()
```

produces invalid XML

```
<node></></node>
```
