### PR TITLE
Removing NPM Warning

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .gitignore
 .travis.yml
 Makefile
-README.md
 .git/
 src/
 test/


### PR DESCRIPTION
When installing with npm I get the following warning:

```
npm WARN package.json xmlbuilder@0.4.1 No README.md file found!
```

I think this is because README.md is in the .npmignore file. I have removed it from this file in this pull request. 

Cheers.
