### PR TITLE
Allow option to include surrogate pairs in XML content

### DIFF
--- a/src/XMLFragment.coffee
+++ b/src/XMLFragment.coffee
@@ -16,7 +16,7 @@ class XMLFragment
     @attributes = attributes
     @value = text
     @children = []
-
+    @assertLegalChar = parent.assertLegalChar
 
   # Creates a child element node
   #
@@ -381,17 +381,6 @@ class XMLFragment
     return str.replace(/&/g, '&amp;')
               .replace(/</g,'&lt;').replace(/>/g,'&gt;')
               .replace(/'/g, '&apos;').replace(/"/g, '&quot;')
-
-
-  # Checks whether the given string contains legal characters
-  # Fails with an exception on error
-  #
-  # `str` the string to check
-  assertLegalChar: (str) ->
-    chars = /[\u0000-\u0008\u000B-\u000C\u000E-\u001F\uD800-\uDFFF\uFFFE-\uFFFF]/
-    chr = str.match chars
-    if chr
-      throw new Error "Invalid character (#{chr}) in string: #{str}"
 
 
   # Checks whether the given object is of the given type

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -7,7 +7,14 @@ module.exports.create = (name, xmldec, doctype) ->
     new XMLBuilder(name, xmldec, doctype).root()
   else
     # This path allows for documents without an xml prolog
-    # It is being kept for compatibility with earlier versions 
+    # It is being kept for compatibility with earlier versions
     # but should be deprecated in the future
     new XMLBuilder()
+
+module.exports.withopts = (options) ->
+    create: (name, xmldec, doctype) ->
+        if name?
+            new XMLBuilder(name, xmldec, doctype, options).root()
+        else
+            new XMLBuilder(null, null, null, options).root()
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -218,3 +218,13 @@ assert.strictEqual(xml14, test14)
 xml15 = '<?xml version="1.1"?><test14><node>test</node></test14>'
 test15 = xmlbuilder.create('test14', { 'version': '1.1' } ).ele('node').txt('test').end()
 assert.strictEqual(xml15, test15)
+
+# Test the use of surrogate pair characters
+stringWithIssues = '𡬁𠻝𩂻耨鬲, 㑜䊑㓣䟉䋮䦓, ᡨᠥ᠙ᡰᢇ᠘ᠶ, ࿋ཇ࿂ོ༇ྒ, ꃌꈗꈉꋽ, Uighur, ᥗᥩᥬᥜᥦ '
+makeXml = (xmlbuilder) ->
+  xmlbuilder.create('test15', {'version': '1.1'}).ele('node').txt(stringWithIssues).end()
+
+assert.throws () -> makeXml(xmlbuilder) Error
+
+# if this doesn't throw we're good
+makeXml xmlbuilder.withopts({allowSurrogateChars: true})


### PR DESCRIPTION
XMLBuilder enforces the rules for valid characters in XML strings. Unfortunately, the Unicode standard has moved on a bit since the XML rules were spec'ed. We've got a need for supporting Asian languages (particularly Chinese) which uses characters that aren't the base multilingual plane (\u0000 - \uFFFF). In 16-bit unicode, these characters are represented by a surrogate pair, two characters in the range \uD800 - \uDFFF. It's not strictly legal XML, but systems that care about Chinese have to be able to produce strings that contain them.

This range of characters is currently blocked by XMLBuilder. This PR adds an option to relax the range checking. I didn't want to change the default behavior, so I made the api look like this:

```
xmlbuilder.withopts({allowSurrogateChars: true}).create(...)
```

We're currently using this in the windows azure SDK for node, and need this for Azure China support.
