### PR TITLE
Empty strings don't match as text-nodes when pretty printing

### DIFF
--- a/src/XMLFragment.coffee
+++ b/src/XMLFragment.coffee
@@ -351,7 +351,7 @@ class XMLFragment
         r += if @name == '?xml' then '?>' else if @name == '!DOCTYPE' then '>' else '/>'
       if pretty
         r += newline
-    else if pretty and @children.length == 1 and @children[0].value
+    else if pretty and @children.length == 1 and @children[0].value?
       # do not indent text-only nodes
       r += '>'
       r += @children[0].value


### PR DESCRIPTION
Empty strings were forcing an indent inside a string node. 

xcode plist reading doesn't trim string inputs so these nodes were erroneously returning whitespace newlines instead of an empty string.
