### PR TITLE
Switch to Lo-Dash

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": "0.8.x || 0.10.x"
   },
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash-node": "~2.4.1"
   },
   "devDependencies": {
     "coffee-script": "~1.6.3",

--- a/src/XMLAttribute.coffee
+++ b/src/XMLAttribute.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents an attribute
 module.exports = class XMLAttribute

--- a/src/XMLBuilder.coffee
+++ b/src/XMLBuilder.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLStringifier = require './XMLStringifier'
 XMLDeclaration = require './XMLDeclaration'

--- a/src/XMLCData.coffee
+++ b/src/XMLCData.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLNode = require './XMLNode'
 

--- a/src/XMLComment.coffee
+++ b/src/XMLComment.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLNode = require './XMLNode'
 

--- a/src/XMLDTDAttList.coffee
+++ b/src/XMLDTDAttList.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents an attribute list
 module.exports = class XMLDTDAttList

--- a/src/XMLDTDElement.coffee
+++ b/src/XMLDTDElement.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents an attribute
 module.exports = class XMLDTDElement

--- a/src/XMLDTDEntity.coffee
+++ b/src/XMLDTDEntity.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents an entity declaration in the DTD
 module.exports = class XMLDTDEntity

--- a/src/XMLDTDNotation.coffee
+++ b/src/XMLDTDNotation.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents a NOTATION entry in the DTD
 module.exports = class XMLDTDNotation

--- a/src/XMLDeclaration.coffee
+++ b/src/XMLDeclaration.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLNode = require './XMLNode'
 

--- a/src/XMLDocType.coffee
+++ b/src/XMLDocType.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents doctype declaration
 module.exports = class XMLDocType

--- a/src/XMLElement.coffee
+++ b/src/XMLElement.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLNode = require './XMLNode'
 XMLAttribute = require './XMLAttribute'

--- a/src/XMLNode.coffee
+++ b/src/XMLNode.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents a generic XMl element
 module.exports = class XMLNode

--- a/src/XMLProcessingInstruction.coffee
+++ b/src/XMLProcessingInstruction.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 # Represents a processing instruction
 module.exports = class XMLProcessingInstruction

--- a/src/XMLRaw.coffee
+++ b/src/XMLRaw.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLNode = require './XMLNode'
 

--- a/src/XMLText.coffee
+++ b/src/XMLText.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLNode = require './XMLNode'
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,4 +1,4 @@
-_ = require 'lodash/dist/lodash.underscore'
+_ = require 'lodash-node'
 
 XMLBuilder = require './XMLBuilder'
 


### PR DESCRIPTION
This PR replaces Underscore with Lo-Dash.

Lo-Dash has lots of features Underscore doesn't, and unlike Underscore, Lo-Dash is tested in Node.js, follows semver, and is now downloaded more on npm than Underscore and has well over a thousand other npm packages depending on it.
