### PR TITLE
Escape according to Canonical XML 1.0

### DIFF
--- a/src/XMLStringifier.coffee
+++ b/src/XMLStringifier.coffee
@@ -17,7 +17,7 @@ module.exports = class XMLStringifier
     @assertLegalChar val
   eleText: (val) ->
     val = '' + val or ''
-    @assertLegalChar @escape val
+    @assertLegalChar @elEscape val
   cdata: (val) ->
     val = '' + val or ''
     if val.match /]]>/
@@ -27,14 +27,14 @@ module.exports = class XMLStringifier
     val = '' + val or ''
     if val.match /--/
       throw new Error "Comment text cannot contain double-hypen: " + val
-    @assertLegalChar @escape val
+    @assertLegalChar val
   raw: (val) ->
     '' + val or ''
   attName: (val) ->
     '' + val or ''
   attValue: (val) ->
     val = '' + val or ''
-    @escape val
+    @attEscape val
   insTarget: (val) ->
     '' + val or ''
   insValue: (val) ->
@@ -95,10 +95,26 @@ module.exports = class XMLStringifier
     str
 
 
-  # Escapes special characters <, >, ', ", &
+  # Escapes special characters in element values
+  #
+  # See http://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping
   #
   # `str` the string to escape
-  escape: (str) ->
+  elEscape: (str) ->
     str.replace(/&/g, '&amp;')
-       .replace(/</g,'&lt;').replace(/>/g,'&gt;')
-       .replace(/'/g, '&apos;').replace(/"/g, '&quot;')
+       .replace(/</g, '&lt;')
+       .replace(/>/g, '&gt;')
+       .replace(/\r/g, '&#xD;')
+
+  # Escapes special characters in attribute values
+  #
+  # See http://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping
+  #
+  # `str` the string to escape
+  attEscape: (str) ->
+    str.replace(/&/g, '&amp;')
+       .replace(/</g, '&lt;')
+       .replace(/"/g, '&quot;')
+       .replace(/\t/g, '&#x9;')
+       .replace(/\n/g, '&#xA;')
+       .replace(/\r/g, '&#xD;')

--- a/test/comment.coffee
+++ b/test/comment.coffee
@@ -1,0 +1,19 @@
+vows = require 'vows'
+assert = require 'assert'
+
+xmlbuilder = require '../src/index.coffee'
+
+vows
+    .describe('Text Processing')
+    .addBatch
+        'Nothing gets escaped':
+            topic: () ->
+                xmlbuilder.create('comment', {}, {}, { headless: true })
+                    .comment('<>\'"&\t\n\r')
+
+            'resulting XML': (topic) ->
+                xml = '<comment><!-- <>\'"&\t\n\r --></comment>'
+                assert.strictEqual topic.doc().toString(), xml
+
+    .export(module)
+

--- a/test/createxml.coffee
+++ b/test/createxml.coffee
@@ -18,8 +18,8 @@ vows
                         .up()
                     .up()
                     .ele('test')
-                        .att('escaped', 'chars <>\'"&')
-                        .txt('complete 100%')
+                        .att('escaped', 'chars <>\'"&\t\n\r')
+                        .txt('complete 100%<>\'"&\t\n\r')
                     .up()
                     .ele('cdata')
                         .cdata('<test att="val">this is a test</test>\nSecond line')
@@ -38,7 +38,7 @@ vows
                               '<!-- CoffeeScript is awesome. -->' +
                               '<repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>' +
                           '</xmlbuilder>' +
-                          '<test escaped="chars &lt;&gt;&apos;&quot;&amp;">complete 100%</test>' +
+                          '<test escaped="chars &lt;>\'&quot;&amp;&#x9;&#xA;&#xD;">complete 100%&lt;&gt;\'"&amp;\t\n&#xD;</test>' +
                           '<cdata><![CDATA[<test att="val">this is a test</test>\nSecond line]]></cdata>' +
                           '<raw>&<>&</raw>' +
                           '<atttest att="val">text</atttest>' +
@@ -54,7 +54,7 @@ vows
                         .nod('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
                         .up()
                     .up()
-                    .ele('test', {'escaped': 'chars <>\'"&'}, 'complete 100%')
+                    .ele('test', {'escaped': 'chars <>\'"&\t\n\r'}, 'complete 100%<>\'"&\t\n\r')
                     .up()
                     .ele('cdata')
                         .cdata('<test att="val">this is a test</test>\nSecond line')
@@ -74,7 +74,7 @@ vows
                               '<!-- CoffeeScript is awesome. -->' +
                               '<repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>' +
                           '</xmlbuilder>' +
-                          '<test escaped="chars &lt;&gt;&apos;&quot;&amp;">complete 100%</test>' +
+                          '<test escaped="chars &lt;>\'&quot;&amp;&#x9;&#xA;&#xD;">complete 100%&lt;&gt;\'"&amp;\t\n&#xD;</test>' +
                           '<cdata><![CDATA[<test att="val">this is a test</test>\nSecond line]]></cdata>' +
                           '<raw>&<>&</raw>' +
                           '<atttest att="val">text</atttest>' +
@@ -90,7 +90,7 @@ vows
                         .nod('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
                         .up()
                     .up()
-                    .ele('test', {'escaped': 'chars <>\'"&'}, 'complete 100%')
+                    .ele('test', {'escaped': 'chars <>\'"&\t\n\r'}, 'complete 100%<>\'"&\t\n\r')
                     .up()
                     .ele('cdata')
                         .cdata('<test att="val">this is a test</test>\nSecond line')
@@ -111,7 +111,7 @@ vows
                               <!-- CoffeeScript is awesome. -->
                               <repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>
                           </xmlbuilder>
-                          <test escaped="chars &lt;&gt;&apos;&quot;&amp;">complete 100%</test>
+                          <test escaped="chars &lt;>\'&quot;&amp;&#x9;&#xA;&#xD;">complete 100%&lt;&gt;\'"&amp;\t\n&#xD;</test>
                           <cdata>
                               <![CDATA[<test att="val">this is a test</test>
                       Second line]]>
@@ -131,7 +131,7 @@ vows
                         .n('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
                         .u()
                     .u()
-                    .e('test', {'escaped': 'chars <>\'"&'}, 'complete 100%')
+                    .e('test', {'escaped': 'chars <>\'"&\t\n\r'}, 'complete 100%<>\'"&\t\n\r')
                     .u()
                     .e('cdata')
                         .d('<test att="val">this is a test</test>\nSecond line')
@@ -150,7 +150,7 @@ vows
                               '<!-- CoffeeScript is awesome. -->' +
                               '<repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>' +
                           '</xmlbuilder>' +
-                          '<test escaped="chars &lt;&gt;&apos;&quot;&amp;">complete 100%</test>' +
+                          '<test escaped="chars &lt;>\'&quot;&amp;&#x9;&#xA;&#xD;">complete 100%&lt;&gt;\'"&amp;\t\n&#xD;</test>' +
                           '<cdata><![CDATA[<test att="val">this is a test</test>\nSecond line]]></cdata>' +
                           '<raw>&<>&</raw>' +
                           '<atttest att="val">text</atttest>' +

--- a/test/text.coffee
+++ b/test/text.coffee
@@ -12,7 +12,7 @@ vows
                     .ele('node', '"')
 
             'resulting XML': (topic) ->
-                xml = '<test8><node>&quot;</node></test8>'
+                xml = '<test8><node>"</node></test8>'
                 assert.strictEqual topic.doc().toString(), xml
 
         'Text node with empty string':


### PR DESCRIPTION
First and foremost, this change allows adding linefeeds, tabs and carriage returns to attribute values.  This was not possible before, since such characters did not get escaped and without escaping a conforming XML reader [will replace them by blanks](http://www.w3.org/TR/2004/REC-xml-20040204/#AVNormalize).

While at it, this change escapes attribute values, text, and comments according to the [Canonical XML 1.0 specification](http://www.w3.org/TR/2000/WD-xml-c14n-20000119.html#charescaping).  In particular, in attribute values greater-than and single quote no longer get escaped; in element values, single and double quotes no longer get escaped but carriage return does get escaped; and in comments, nothing gets escaped.
