### PR TITLE
Allowing empty elements

### DIFF
--- a/src/XMLElement.coffee
+++ b/src/XMLElement.coffee
@@ -126,6 +126,7 @@ module.exports = class XMLElement extends XMLNode
     indent = options?.indent ? '  '
     offset = options?.offset ? 0
     newline = options?.newline ? '\n'
+    allowEmpty = options?.allowEmpty ? false
     level or= 0
 
     space = new Array(level + offset + 1).join(indent)
@@ -146,7 +147,11 @@ module.exports = class XMLElement extends XMLNode
 
     if @children.length == 0 or every(@children, (e) -> e.value == '')
       # empty element
-      r += '/>'
+      if allowEmpty
+        r += '></' + @name + '>'
+      else
+        r += '/>'
+
       r += newline if pretty
     else if pretty and @children.length == 1 and @children[0].value?
       # do not indent text-only nodes

--- a/test/basic/createxml.coffee
+++ b/test/basic/createxml.coffee
@@ -269,3 +269,11 @@ suite 'Creating XML:', ->
       '<test14><node>test</node></test14>'
     )
 
+
+  test 'create() allowing empty elements', ->
+    eq(
+      xml('test15', { version: '1.0', encoding: 'UTF-8'})
+        .ele('node').end({allowEmpty: true})
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<test15><node></node></test15>'
+    )


### PR DESCRIPTION
Option to allow empty elements. Instead of `<node/>`, will render `<node></node>`.