### PR TITLE
Added support for nested CDATA

### DIFF
--- a/src/XMLStringifier.coffee
+++ b/src/XMLStringifier.coffee
@@ -22,8 +22,7 @@ module.exports = class XMLStringifier
     @assertLegalChar @elEscape val
   cdata: (val) ->
     val = '' + val or ''
-    if val.match /]]>/
-      throw new Error "Invalid CDATA text: " + val
+    val = val.replace(']]>', ']]]]><![CDATA[>')
     @assertLegalChar val
   comment: (val) ->
     val = '' + val or ''

--- a/test/basic/cdata.coffee
+++ b/test/basic/cdata.coffee
@@ -1,0 +1,8 @@
+suite 'CDATA', ->
+  test 'Nested CDATA', ->
+    eq(
+      xml('test', {}, {}, { headless: true })
+        .cdata('foo and <![CDATA[<foo>bar</foo>]]> bar')
+      .end()
+      '<test><![CDATA[foo and <![CDATA[<foo>bar</foo>]]]]><![CDATA[> bar]]></test>'
+    )

--- a/test/guards/stringify.coffee
+++ b/test/guards/stringify.coffee
@@ -1,7 +1,6 @@
 suite 'Stringify Guards:', ->
   test 'defaults', ->
     testCases = [
-      () -> xml('test').dat(']]>')
       () -> xml('test').com('--')
       () -> xml('test').ins('pi', '?>')
       () -> xml('test', { encoding: "A#" })
@@ -9,7 +8,6 @@ suite 'Stringify Guards:', ->
     ]
 
     results = [
-      /Invalid CDATA text: ]]>/
       /Comment text cannot contain double-hypen: --/
       /Invalid processing instruction value: \?>/
       /Invalid encoding: A#/


### PR DESCRIPTION
Right now, trying to create CDATA that includes `]]>` throws an error, but it's [easy to escape that string within CDATA](https://en.wikipedia.org/wiki/CDATA#Nesting).