### PR TITLE
Allow negative offset and add option to suppress pretty for elements containing text

### DIFF
--- a/src/XMLStringWriter.coffee
+++ b/src/XMLStringWriter.coffee
@@ -26,13 +26,12 @@ module.exports = class XMLStringWriter extends XMLWriterBase
   # `options.newline` newline sequence
   # `options.offset` a fixed number of indentations to add to every line
   # `options.allowEmpty` do not self close empty element tags
+  # 'options.dontprettytextnodes' if any text is present in node, don't indent or LF
   constructor: (options) ->
     super options
 
   document: (doc) ->
     @textispresent = false
-    @newlinedefault = @newline
-    @prettydefault = @pretty
     r = ''
     for child in doc.children
       r += switch

--- a/src/XMLWriterBase.coffee
+++ b/src/XMLWriterBase.coffee
@@ -9,6 +9,7 @@ module.exports = class XMLWriterBase
   # `options.newline` newline sequence
   # `options.offset` a fixed number of indentations to add to every line
   # `options.allowEmpty` do not self close empty element tags
+  # 'options.dontprettytextnodes' if any text is present in node, don't indent or LF
   constructor: (options) ->
     options or= {}
     @pretty = options.pretty or false
@@ -23,6 +24,10 @@ module.exports = class XMLWriterBase
       @newline = ''
       @offset = 0
       @dontprettytextnodes = 0
+
+    # create local copies of these two for later
+    @newlinedefault = @newline
+    @prettydefault = @pretty
 
     # overwrite default properties
     for own key, value of options.writer or {}
@@ -43,6 +48,10 @@ module.exports = class XMLWriterBase
       @newline = ''
       @offset = 0
       @dontprettytextnodes = 0
+
+    # create local copies of these two for later
+    @newlinedefault = @newline
+    @prettydefault = @pretty
 
     # overwrite default properties
     for own key, value of options.writer or {}

--- a/src/XMLWriterBase.coffee
+++ b/src/XMLWriterBase.coffee
@@ -17,10 +17,12 @@ module.exports = class XMLWriterBase
       @indent = options.indent ? '  '
       @newline = options.newline ? '\n'
       @offset = options.offset ? 0
+      @dontprettytextnodes = options.dontprettytextnodes ? 0
     else
       @indent = ''
       @newline = ''
       @offset = 0
+      @dontprettytextnodes = 0
 
     # overwrite default properties
     for own key, value of options.writer or {}
@@ -35,10 +37,12 @@ module.exports = class XMLWriterBase
       @indent = if "indent" of options then options.indent else '  '
       @newline = if "newline" of options then options.newline else '\n'
       @offset = if "offset" of options then options.offset else 0
+      @dontprettytextnodes =  if "dontprettytextnodes" of options then options.dontprettytextnodes else 0
     else
       @indent = ''
       @newline = ''
       @offset = 0
+      @dontprettytextnodes = 0
 
     # overwrite default properties
     for own key, value of options.writer or {}

--- a/src/XMLWriterBase.coffee
+++ b/src/XMLWriterBase.coffee
@@ -49,6 +49,10 @@ module.exports = class XMLWriterBase
   # returns the indentation string for the current level
   space: (level) ->
     if @pretty
-      new Array((level or 0) + @offset + 1).join(@indent)
+      indent = (level or 0) + @offset + 1
+      if indent > 0
+        new Array(indent).join(@indent)
+      else
+        ''
     else
       ''

--- a/test/basic/stringwriter.coffee
+++ b/test/basic/stringwriter.coffee
@@ -202,6 +202,51 @@ suite 'Creating XML with string writer:', ->
       ) #Heredoc format indenting is based on the first non-whitespace character, so we add extra, then replace it
     )
 
+
+  test 'Pretty printing with -ve offset', ->
+    eq(
+      xml('root')
+        .ele('xmlbuilder', {'for': 'node-js' })
+            .com('CoffeeScript is awesome.')
+            .nod('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
+            .up()
+        .up()
+        .ele('cdata')
+            .cdata('<test att="val">this is a test</test>\nSecond line')
+        .up()
+        .ele('raw')
+            .raw('&<>&')
+            .up()
+        .ele('atttest', { 'att': 'val' }, 'text')
+            .up()
+        .ele('atttest', 'text')
+            .att('att', () -> 'val')
+        .end(builder.stringWriter( { pretty: true, indent: '    ', offset : -2 } ))
+
+      """
+        TEMPORARY_INDENT
+        <?xml version="1.0"?>
+        <root>
+        <xmlbuilder for="node-js">
+        <!-- CoffeeScript is awesome. -->
+        <repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>
+        </xmlbuilder>
+        <cdata>
+        <![CDATA[<test att="val">this is a test</test>
+        Second line]]>
+        </cdata>
+        <raw>&<>&</raw>
+        <atttest att="val">text</atttest>
+        <atttest att="val">text</atttest>
+        </root>
+      """.replace(
+        ///
+          TEMPORARY_INDENT\n
+        ///
+        ''
+      ) #Heredoc format indenting is based on the first non-whitespace character, so we add extra, then replace it
+    )
+
   test 'Pretty printing with empty indent', ->
     eq(
       xml('root')
@@ -236,6 +281,257 @@ suite 'Creating XML with string writer:', ->
       <raw>&<>&</raw>
       <atttest att="val">text</atttest>
       <atttest att="val">text</atttest>
+      </root>
+      """
+    )
+
+
+  test 'Pretty printing with dontprettytextnodes, no mixed content', ->
+    eq(
+      xml('root')
+        .dtd('hello.dtd')
+            .ins('pub_border', 'thin')
+            .ele('img', 'EMPTY')
+            .com('Image attributes follow')
+            .att('img', 'height', 'CDATA', '#REQUIRED')
+            .att('img', 'visible', '(yes|no)', '#DEFAULT', "yes")
+            .not('fs', { sysID: 'http://my.fs.com/reader' })
+            .not('fs-nt', { pubID: 'FS Network Reader 1.0' })
+            .not('fs-nt', { pubID: 'FS Network Reader 1.0', sysID: 'http://my.fs.com/reader' })
+            .att('img', 'src', 'NOTATION (fs|fs-nt)', '#REQUIRED')
+            .dat('<owner>John</owner>')
+            .ele('node')
+            .ent('ent', 'my val')
+            .ent('ent', { sysID: 'http://www.myspec.com/ent' })
+            .ent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent' })
+            .ent('ent', { sysID: 'http://www.myspec.com/ent', nData: 'entprg' })
+            .ent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent', nData: 'entprg' })
+            .pent('ent', 'my val')
+            .pent('ent', { sysID: 'http://www.myspec.com/ent' })
+            .pent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent' })
+            .ele('nodearr', ['a', 'b'])
+        .root()
+        .ele('xmlbuilder', {'for': 'node-js' })
+            .com('CoffeeScript is awesome.')
+            .nod('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
+            .up()
+        .up()
+        .ele('cdata')
+            .cdata('<test att="val">this is a test</test>\nSecond line')
+        .up()
+        .ele('raw')
+            .raw('&<>&')
+            .up()
+        .ele('atttest', { 'att': 'val' }, 'text')
+            .up()
+        .ele('atttest', 'text')
+            .att('att', () -> 'val')
+        .end(builder.stringWriter( { pretty: true, indent: '    ', dontprettytextnodes: true } ))
+
+      """
+      <?xml version="1.0"?>
+      <!DOCTYPE root SYSTEM "hello.dtd" [
+          <?pub_border thin?>
+          <!ELEMENT img EMPTY>
+          <!-- Image attributes follow -->
+          <!ATTLIST img height CDATA #REQUIRED>
+          <!ATTLIST img visible (yes|no) "yes">
+          <!NOTATION fs SYSTEM "http://my.fs.com/reader">
+          <!NOTATION fs-nt PUBLIC "FS Network Reader 1.0">
+          <!NOTATION fs-nt PUBLIC "FS Network Reader 1.0" "http://my.fs.com/reader">
+          <!ATTLIST img src NOTATION (fs|fs-nt) #REQUIRED>
+          <![CDATA[<owner>John</owner>]]>
+          <!ELEMENT node (#PCDATA)>
+          <!ENTITY ent "my val">
+          <!ENTITY ent SYSTEM "http://www.myspec.com/ent">
+          <!ENTITY ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent">
+          <!ENTITY ent SYSTEM "http://www.myspec.com/ent" NDATA entprg>
+          <!ENTITY ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent" NDATA entprg>
+          <!ENTITY % ent "my val">
+          <!ENTITY % ent SYSTEM "http://www.myspec.com/ent">
+          <!ENTITY % ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent">
+          <!ELEMENT nodearr (a,b)>
+      ]>
+      <root>
+          <xmlbuilder for="node-js">
+              <!-- CoffeeScript is awesome. -->
+              <repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>
+          </xmlbuilder>
+          <cdata>
+              <![CDATA[<test att="val">this is a test</test>
+      Second line]]>
+          </cdata>
+          <raw>&<>&</raw>
+          <atttest att="val">text</atttest>
+          <atttest att="val">text</atttest>
+      </root>
+      """
+    )
+
+  test 'Pretty printing with mixed content, dontprettytextmode unset', ->
+    eq(
+      xml('root')
+        .dtd('hello.dtd')
+            .ins('pub_border', 'thin')
+            .ele('img', 'EMPTY')
+            .com('Image attributes follow')
+            .att('img', 'height', 'CDATA', '#REQUIRED')
+            .att('img', 'visible', '(yes|no)', '#DEFAULT', "yes")
+            .not('fs', { sysID: 'http://my.fs.com/reader' })
+            .not('fs-nt', { pubID: 'FS Network Reader 1.0' })
+            .not('fs-nt', { pubID: 'FS Network Reader 1.0', sysID: 'http://my.fs.com/reader' })
+            .att('img', 'src', 'NOTATION (fs|fs-nt)', '#REQUIRED')
+            .dat('<owner>John</owner>')
+            .ele('node')
+            .ent('ent', 'my val')
+            .ent('ent', { sysID: 'http://www.myspec.com/ent' })
+            .ent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent' })
+            .ent('ent', { sysID: 'http://www.myspec.com/ent', nData: 'entprg' })
+            .ent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent', nData: 'entprg' })
+            .pent('ent', 'my val')
+            .pent('ent', { sysID: 'http://www.myspec.com/ent' })
+            .pent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent' })
+            .ele('nodearr', ['a', 'b'])
+        .root()
+        .ele('xmlbuilder', {'for': 'node-js' })
+            .com('CoffeeScript is awesome.')
+            .nod('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
+            .up()
+        .up()
+        .ele('cdata')
+            .cdata('<test att="val">this is a test</test>\nSecond line')
+        .up()
+        .ele('raw')
+            .raw('&<>&')
+            .up()
+        .ele('atttest', { 'att': 'val' }, 'mixed content')
+        .ele('atttest', 'text')
+            .att('att', () -> 'val')
+            .up()
+        .txt('moretext after node')
+        .end(builder.stringWriter( { pretty: true, indent: '    '} ))
+
+      """
+      <?xml version="1.0"?>
+      <!DOCTYPE root SYSTEM "hello.dtd" [
+          <?pub_border thin?>
+          <!ELEMENT img EMPTY>
+          <!-- Image attributes follow -->
+          <!ATTLIST img height CDATA #REQUIRED>
+          <!ATTLIST img visible (yes|no) "yes">
+          <!NOTATION fs SYSTEM "http://my.fs.com/reader">
+          <!NOTATION fs-nt PUBLIC "FS Network Reader 1.0">
+          <!NOTATION fs-nt PUBLIC "FS Network Reader 1.0" "http://my.fs.com/reader">
+          <!ATTLIST img src NOTATION (fs|fs-nt) #REQUIRED>
+          <![CDATA[<owner>John</owner>]]>
+          <!ELEMENT node (#PCDATA)>
+          <!ENTITY ent "my val">
+          <!ENTITY ent SYSTEM "http://www.myspec.com/ent">
+          <!ENTITY ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent">
+          <!ENTITY ent SYSTEM "http://www.myspec.com/ent" NDATA entprg>
+          <!ENTITY ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent" NDATA entprg>
+          <!ENTITY % ent "my val">
+          <!ENTITY % ent SYSTEM "http://www.myspec.com/ent">
+          <!ENTITY % ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent">
+          <!ELEMENT nodearr (a,b)>
+      ]>
+      <root>
+          <xmlbuilder for="node-js">
+              <!-- CoffeeScript is awesome. -->
+              <repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>
+          </xmlbuilder>
+          <cdata>
+              <![CDATA[<test att="val">this is a test</test>
+      Second line]]>
+          </cdata>
+          <raw>&<>&</raw>
+          <atttest att="val">
+              mixed content
+              <atttest att="val">text</atttest>
+              moretext after node
+          </atttest>
+      </root>
+      """
+    )
+
+  test 'Pretty printing with mixed content, dontprettytextmode set to true', ->
+    eq(
+      xml('root')
+        .dtd('hello.dtd')
+            .ins('pub_border', 'thin')
+            .ele('img', 'EMPTY')
+            .com('Image attributes follow')
+            .att('img', 'height', 'CDATA', '#REQUIRED')
+            .att('img', 'visible', '(yes|no)', '#DEFAULT', "yes")
+            .not('fs', { sysID: 'http://my.fs.com/reader' })
+            .not('fs-nt', { pubID: 'FS Network Reader 1.0' })
+            .not('fs-nt', { pubID: 'FS Network Reader 1.0', sysID: 'http://my.fs.com/reader' })
+            .att('img', 'src', 'NOTATION (fs|fs-nt)', '#REQUIRED')
+            .dat('<owner>John</owner>')
+            .ele('node')
+            .ent('ent', 'my val')
+            .ent('ent', { sysID: 'http://www.myspec.com/ent' })
+            .ent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent' })
+            .ent('ent', { sysID: 'http://www.myspec.com/ent', nData: 'entprg' })
+            .ent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent', nData: 'entprg' })
+            .pent('ent', 'my val')
+            .pent('ent', { sysID: 'http://www.myspec.com/ent' })
+            .pent('ent', { pubID: '-//MY//SPEC ENT//EN', sysID: 'http://www.myspec.com/ent' })
+            .ele('nodearr', ['a', 'b'])
+        .root()
+        .ele('xmlbuilder', {'for': 'node-js' })
+            .com('CoffeeScript is awesome.')
+            .nod('repo', {'type': 'git'}, 'git://github.com/oozcitak/xmlbuilder-js.git')
+            .up()
+        .up()
+        .ele('cdata')
+            .cdata('<test att="val">this is a test</test>\nSecond line')
+        .up()
+        .ele('raw')
+            .raw('&<>&')
+            .up()
+        .ele('atttest', { 'att': 'val' }, 'mixed content')
+        .ele('atttest', 'text')
+            .att('att', () -> 'val')
+            .up()
+        .txt('moretext after node')
+        .end(builder.stringWriter( { pretty: true, indent: '    ', dontprettytextnodes: true} ))
+
+      """
+      <?xml version="1.0"?>
+      <!DOCTYPE root SYSTEM "hello.dtd" [
+          <?pub_border thin?>
+          <!ELEMENT img EMPTY>
+          <!-- Image attributes follow -->
+          <!ATTLIST img height CDATA #REQUIRED>
+          <!ATTLIST img visible (yes|no) "yes">
+          <!NOTATION fs SYSTEM "http://my.fs.com/reader">
+          <!NOTATION fs-nt PUBLIC "FS Network Reader 1.0">
+          <!NOTATION fs-nt PUBLIC "FS Network Reader 1.0" "http://my.fs.com/reader">
+          <!ATTLIST img src NOTATION (fs|fs-nt) #REQUIRED>
+          <![CDATA[<owner>John</owner>]]>
+          <!ELEMENT node (#PCDATA)>
+          <!ENTITY ent "my val">
+          <!ENTITY ent SYSTEM "http://www.myspec.com/ent">
+          <!ENTITY ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent">
+          <!ENTITY ent SYSTEM "http://www.myspec.com/ent" NDATA entprg>
+          <!ENTITY ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent" NDATA entprg>
+          <!ENTITY % ent "my val">
+          <!ENTITY % ent SYSTEM "http://www.myspec.com/ent">
+          <!ENTITY % ent PUBLIC "-//MY//SPEC ENT//EN" "http://www.myspec.com/ent">
+          <!ELEMENT nodearr (a,b)>
+      ]>
+      <root>
+          <xmlbuilder for="node-js">
+              <!-- CoffeeScript is awesome. -->
+              <repo type="git">git://github.com/oozcitak/xmlbuilder-js.git</repo>
+          </xmlbuilder>
+          <cdata>
+              <![CDATA[<test att="val">this is a test</test>
+      Second line]]>
+          </cdata>
+          <raw>&<>&</raw>
+          <atttest att="val">mixed content<atttest att="val">text</atttest>moretext after node</atttest>
       </root>
       """
     )


### PR DESCRIPTION
hi oozcitak,
please see attached changes.

The first one allows negative 'offset' option - which basically enables:
```xml
<root>
<node>
    <subnode>
    </subnode>
</node>
</root>
```
(note how <node> is not indented)
I found this useful as I'm stripping off '<root>' in the text domain; and the fix also prevents a crash if offset < -1 is set; so it's viable just for that.

The second is about mixed content nodes.
I have:
```xml
<root>
  <node>sometext<subnode>moretext</subnode>even more text </node>
</root>
```
and pretty print does this:
```xml
<root>
  <node>
    sometext
    <subnode>
       moretext
    </subnode>
    even more text 
  </node>
</root>
```
so I've added an additional option 'dontprettytextnodes' which when set results in the pretty reproducing my 'input' - i.e. it detect if ANY text is in an element, and if there is, turns off pretty (indent and newline) for that element and all children.  I believe this to be more XML compliant; but I don't pretend to understand XMLs treatment of spaces - it seems a huge can of worms :).



