### PR TITLE
Use an ES5 compatible Regexp to assert legal characters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "4.0"
+  - "5.0"
   - "6.0"
   - "node"
 after_success:

--- a/src/XMLStringifier.coffee
+++ b/src/XMLStringifier.coffee
@@ -86,7 +86,9 @@ module.exports = class XMLStringifier
     # Valid characters from https://www.w3.org/TR/xml11/#charsets
     # any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
     # [#x1-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-    res = str.match /[\u{0000}\u{D800}-\u{DFFF}\u{FFFE}-\u{FFFF}]/u
+    # This complex ES5 compatible Regexp has been generated using the "regenerate" NPM module
+    # `regenerate().add(0x0000).addRange(0xD800, 0xDFFF).addRange(0xFFFE, 0xFFFF).toString()`
+    res = str.match /[\0\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
     if res
       throw new Error "Invalid character in string: #{str} at index #{res.index}"
 


### PR DESCRIPTION
We were very happy about the fix for #147, because we also have users using emoji. But some of them still uses IE11 in their companies. IE11 stops the JavaScript parsing on the unknown `u` Regex flag.

This PR restores ES5 compatibility by replacing the legible ES6 Regexp with a more complex one generated using https://github.com/mathiasbynens/regenerate