### PR TITLE
Fix bug where newlines were added at start and end of CDATA.

### DIFF
--- a/src/XMLStreamWriter.coffee
+++ b/src/XMLStreamWriter.coffee
@@ -114,8 +114,8 @@ module.exports = class XMLStreamWriter extends XMLWriterBase
       else
         options.state = WriterState.CloseTag
         @stream.write options.spaceBeforeSlash + '/>'
-    else if options.pretty and childNodeCount == 1 and (firstChildNode.type is NodeType.Text or firstChildNode.type is NodeType.Raw) and firstChildNode.value?
-      # do not indent text-only nodes
+    else if options.pretty and childNodeCount == 1 and (firstChildNode.type is NodeType.Text or firstChildNode.type is NodeType.Raw or firstChildNode.type is NodeType.CData) and firstChildNode.value?
+      # do not indent text-only or CDATA nodes
       @stream.write '>'
       options.state = WriterState.InsideTag
       options.suppressPrettyCount++

--- a/src/XMLWriterBase.coffee
+++ b/src/XMLWriterBase.coffee
@@ -105,6 +105,7 @@ module.exports = class XMLWriterBase
     return r
 
   cdata: (node, options, level) ->
+    options.suppressPrettyCount++
     @openNode(node, options, level)
     options.state = WriterState.OpenTag
     r = @indent(node, options, level) + '<![CDATA['
@@ -114,6 +115,7 @@ module.exports = class XMLWriterBase
     r += ']]>' + @endline(node, options, level)
     options.state = WriterState.None
     @closeNode(node, options, level)
+    options.suppressPrettyCount--
 
     return r
 
@@ -217,7 +219,7 @@ module.exports = class XMLWriterBase
       else
         options.state = WriterState.CloseTag
         r += options.spaceBeforeSlash + '/>' + @endline(node, options, level)
-    else if options.pretty and childNodeCount == 1 and (firstChildNode.type is NodeType.Text or firstChildNode.type is NodeType.Raw) and firstChildNode.value?
+    else if options.pretty and childNodeCount == 1 and (firstChildNode.type is NodeType.Text or firstChildNode.type is NodeType.Raw or firstChildNode.type is NodeType.CData) and firstChildNode.value?
       # do not indent text-only nodes
       r += '>'
       options.state = WriterState.InsideTag


### PR DESCRIPTION
Without this patch, spaces and newlines are added to elements that contain CDATA. This was a problem for our application. Without this patch, pretty printed elements which contain CDATA are output as:
```
<elemName>
  <![CDATA[some data here]]>
</elemName>
```
With this patch, the output is:
```
<elemName><![CDATA[some data here]]></elemName>
```