### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An XML builder for [node.js](https://nodejs.org/) similar to
 
 ### Announcing `xmlbuilder2`:
 
-The new release of `xmlbuilder` is available at [`xmlbuilder2`](https://github.com/oozcitak/xmlbuilder2)! `xmlbuilder2` has been redesigned from the ground up to be fully conforming to the [modern DOM specification](https://dom.spec.whatwg.org). It supports XML namespaces, provides built-in converters for multiple formats, collection functions, and more. Please see [upgrading from xmlbuilder](https://github.com/oozcitak/xmlbuilder2/wiki/Upgrading-from-xmlbuilder) in the wiki.
+The new release of `xmlbuilder` is available at [`xmlbuilder2`](xmlbuilder2)! `xmlbuilder2` has been redesigned from the ground up to be fully conforming to the [modern DOM specification](https://dom.spec.whatwg.org). It supports XML namespaces, provides built-in converters for multiple formats, collection functions, and more. Please see [upgrading from xmlbuilder](https://github.com/oozcitak/xmlbuilder2/wiki/Upgrading-from-xmlbuilder) in the wiki.
 
 New development will be focused towards `xmlbuilder2`; `xmlbuilder` will only receive critical bug fixes.
 


### PR DESCRIPTION
shortened link, means that the npm description links to the npm description on `xmlbuilder2`, and the github readme links to the `xmlbuilder2` readme.